### PR TITLE
Add In-Memory Rate Limiter For Endpoints

### DIFF
--- a/api/docs/docs.go
+++ b/api/docs/docs.go
@@ -43,7 +43,7 @@ const docTemplate = `{
                     "200": {
                         "description": "JWT token",
                         "schema": {
-                            "$ref": "#/definitions/response.JwtReponse"
+                            "$ref": "#/definitions/response.JwtResponse"
                         }
                     },
                     "400": {
@@ -168,6 +168,12 @@ const docTemplate = `{
                             "$ref": "#/definitions/response.ResponseErrorModel"
                         }
                     },
+                    "429": {
+                        "description": "Rate Limit Exceeded",
+                        "schema": {
+                            "$ref": "#/definitions/response.ResponseErrorModel"
+                        }
+                    },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
@@ -218,6 +224,12 @@ const docTemplate = `{
                             "$ref": "#/definitions/response.ResponseErrorModel"
                         }
                     },
+                    "429": {
+                        "description": "Rate Limit Exceeded",
+                        "schema": {
+                            "$ref": "#/definitions/response.ResponseErrorModel"
+                        }
+                    },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
@@ -258,7 +270,7 @@ const docTemplate = `{
                 }
             }
         },
-        "response.JwtReponse": {
+        "response.JwtResponse": {
             "type": "object",
             "properties": {
                 "jwt": {

--- a/api/docs/swagger.json
+++ b/api/docs/swagger.json
@@ -40,7 +40,7 @@
                     "200": {
                         "description": "JWT token",
                         "schema": {
-                            "$ref": "#/definitions/response.JwtReponse"
+                            "$ref": "#/definitions/response.JwtResponse"
                         }
                     },
                     "400": {
@@ -165,6 +165,12 @@
                             "$ref": "#/definitions/response.ResponseErrorModel"
                         }
                     },
+                    "429": {
+                        "description": "Rate Limit Exceeded",
+                        "schema": {
+                            "$ref": "#/definitions/response.ResponseErrorModel"
+                        }
+                    },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
@@ -215,6 +221,12 @@
                             "$ref": "#/definitions/response.ResponseErrorModel"
                         }
                     },
+                    "429": {
+                        "description": "Rate Limit Exceeded",
+                        "schema": {
+                            "$ref": "#/definitions/response.ResponseErrorModel"
+                        }
+                    },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
@@ -255,7 +267,7 @@
                 }
             }
         },
-        "response.JwtReponse": {
+        "response.JwtResponse": {
             "type": "object",
             "properties": {
                 "jwt": {

--- a/api/docs/swagger.yaml
+++ b/api/docs/swagger.yaml
@@ -19,7 +19,7 @@ definitions:
     - password
     - username
     type: object
-  response.JwtReponse:
+  response.JwtResponse:
     properties:
       jwt:
         type: string
@@ -72,7 +72,7 @@ paths:
         "200":
           description: JWT token
           schema:
-            $ref: '#/definitions/response.JwtReponse'
+            $ref: '#/definitions/response.JwtResponse'
         "400":
           description: Bad Request
           schema:
@@ -152,6 +152,10 @@ paths:
           description: Not Found
           schema:
             $ref: '#/definitions/response.ResponseErrorModel'
+        "429":
+          description: Rate Limit Exceeded
+          schema:
+            $ref: '#/definitions/response.ResponseErrorModel'
         "500":
           description: Internal Server Error
           schema:
@@ -184,6 +188,10 @@ paths:
             $ref: '#/definitions/response.ResponseErrorModel'
         "409":
           description: Conflict
+          schema:
+            $ref: '#/definitions/response.ResponseErrorModel'
+        "429":
+          description: Rate Limit Exceeded
           schema:
             $ref: '#/definitions/response.ResponseErrorModel'
         "500":

--- a/api/main.go
+++ b/api/main.go
@@ -3,7 +3,9 @@ package main
 import (
 	"log"
 	"os"
+	"time"
 
+	"github.com/RyanDerr/GoShorty/api/middleware"
 	"github.com/RyanDerr/GoShorty/api/routes"
 	"github.com/RyanDerr/GoShorty/internal/domain/entity"
 	"github.com/RyanDerr/GoShorty/pkg/cache"
@@ -25,7 +27,20 @@ func loadDatabase() (*gorm.DB, error) {
 	return db, nil
 }
 
+func setupRateLimits() (*middleware.RateLimiter, *middleware.RateLimiter) {
+	// Setup rate limits for shortening and resolving URLs with a refill rate of 1 token per 6 seconds, with a max of 10 tokens
+	shortUrlRateLimit := middleware.NewRateLimiter(10, 1, time.Second*6)
+	go shortUrlRateLimit.RefillTokens()
+
+	// Setup rate limits for getting short URLs with a refill rate of 1 token per second, with a max of 60 tokens
+	getShortRateLimit := middleware.NewRateLimiter(60, 1, time.Second)
+	go getShortRateLimit.RefillTokens()
+
+	return shortUrlRateLimit, getShortRateLimit
+}
+
 func main() {
+	// Setup user database and Redis cache
 	db, err := loadDatabase()
 	if err != nil {
 		log.Fatalf("Error loading database: %v", err)
@@ -36,8 +51,12 @@ func main() {
 		log.Fatalf("Error creating Redis client: %v", err)
 	}
 
+	// Setup rate limits for shortening and resolving URLs
+	shortUrlRateLimit, getShortRateLimit := setupRateLimits()
+
+	// Setup and run the Gin router
 	port := os.Getenv("PORT")
-	app := routes.SetupRouter(redis, db)
+	app := routes.SetupRouter(redis, db, shortUrlRateLimit, getShortRateLimit)
 
 	if err := app.Run(":" + port); err != nil {
 		log.Fatalf("Error starting server: %v", err)

--- a/api/middleware/middleware.go
+++ b/api/middleware/middleware.go
@@ -29,7 +29,7 @@ func CORSMiddleware() gin.HandlerFunc {
 		c.Writer.Header().Set("Access-Control-Allow-Method", "POST, GET, DELETE, PUT")
 
 		if c.Request.Method == "OPTIONS" {
-			c.AbortWithStatus(204)
+			c.AbortWithStatus(http.StatusNoContent)
 			return
 		}
 

--- a/api/middleware/rate_limit.go
+++ b/api/middleware/rate_limit.go
@@ -1,0 +1,67 @@
+package middleware
+
+import (
+	"net/http"
+	"sync"
+	"time"
+
+	"github.com/RyanDerr/GoShorty/pkg/response"
+	"github.com/gin-gonic/gin"
+)
+
+type RateLimiter struct {
+	tokens     int
+	maxTokens  int
+	refillRate int
+	dur        time.Duration
+	mutex      sync.Mutex
+}
+
+func NewRateLimiter(maxTokens, refillRate int, duration time.Duration) *RateLimiter {
+	return &RateLimiter{
+		tokens:     maxTokens,
+		maxTokens:  maxTokens,
+		refillRate: refillRate,
+		dur:        duration,
+	}
+}
+
+// RefillTokens is a method that refills the tokens of the RateLimiter set duration with a mutex lock for thread safety.
+func (rl *RateLimiter) RefillTokens() {
+	for {
+		time.Sleep(rl.dur)
+		rl.mutex.Lock()
+		if rl.tokens < rl.maxTokens {
+			rl.tokens += rl.refillRate
+		}
+
+		if rl.tokens > rl.maxTokens {
+			rl.tokens = rl.maxTokens
+		}
+		rl.mutex.Unlock()
+	}
+}
+
+// acquireToken is a method that acquires a token from the RateLimiter with a mutex lock for thread safety.
+func (rl *RateLimiter) acquireToken() bool {
+	rl.mutex.Lock()
+	defer rl.mutex.Unlock()
+
+	if rl.tokens > 0 {
+		rl.tokens--
+		return true
+	}
+	return false
+}
+
+// IsRateLimited is a middleware function that checks if the RateLimiter is rate limited and returns a 429 status code if it is.
+func (rl *RateLimiter) IsRateLimited() gin.HandlerFunc {
+	return func(c *gin.Context) {
+		if !rl.acquireToken() {
+			response.ResponseError(c, "Rate limit exceeded", http.StatusTooManyRequests)
+			c.Abort()
+			return
+		}
+		c.Next()
+	}
+}

--- a/internal/domain/handler/url_handler.go
+++ b/internal/domain/handler/url_handler.go
@@ -32,6 +32,7 @@ func NewUrlHandler(urlService service.IUrlService) *UrlHandler {
 //	@Success		201			{object}	response.ShortenUrlResponse	"Shortened URL"
 //	@Failure		400			{object}	response.ResponseErrorModel	"Bad Request"
 //	@Failure		409			{object}	response.ResponseErrorModel	"Conflict"
+//	@Failure		429			{object}	response.ResponseErrorModel	"Rate Limit Exceeded"
 //	@Failure		500			{object}	response.ResponseErrorModel	"Internal Server Error"
 //	@Router			/url/shorten [post]
 func (h *UrlHandler) ShortenUrl(ctx *gin.Context) {
@@ -79,6 +80,7 @@ func (h *UrlHandler) ShortenUrl(ctx *gin.Context) {
 //	@Success		301		{string}	string						"Redirect to original URL"
 //	@Failure		400		{object}	response.ResponseErrorModel	"Bad Request"
 //	@Failure		404		{object}	response.ResponseErrorModel	"Not Found"
+//	@Failure		429		{object}	response.ResponseErrorModel	"Rate Limit Exceeded"
 //	@Failure		500		{object}	response.ResponseErrorModel	"Internal Server Error"
 //	@Router			/url/{short} [get]
 func (h *UrlHandler) ResolveUrl(ctx *gin.Context) {

--- a/internal/domain/handler/user_handler.go
+++ b/internal/domain/handler/user_handler.go
@@ -64,7 +64,7 @@ func (h *UserHandler) RegisterUser(ctx *gin.Context) {
 //	@Accept			json
 //	@Produce		json
 //	@Param			user	body		request.UserAuthInput		true	"User credentials"
-//	@Success		200		{object}	response.JwtReponse			"JWT token"
+//	@Success		200		{object}	response.JwtResponse		"JWT token"
 //	@Failure		400		{object}	response.ResponseErrorModel	"Bad Request"
 //	@Failure		401		{object}	response.ResponseErrorModel	"Unauthorized"
 //	@Failure		404		{object}	response.ResponseErrorModel	"Not Found"


### PR DESCRIPTION
## Overview
- Create a rate limiter for shortened URL endpoints
   - `10` requests per minute with a 1 token refill per `6` seconds for shortened URLs.
   - `60` requests per minute for a shortened URL with a refill of `1` token per second. 
- Update the OpenAPI spec for `TooManyRequests`
<!-- Provide a brief overview and or bullet point of changes made -->

## Testing
- Manually tested via insomnia requests
   - Future requests may want to be tested with [k6](https://github.com/grafana/k6)
<!-- Enumerate details if any for testing that was done before publishing PR -->

## Checklist 
- [x] If applicable, I've documented a plan to revert these changes if it requires more than reverting the PR. 

## Notes
N/A
<!-- Any additional details to provide regarding the PR -->